### PR TITLE
determine supported/required ruby version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: ruby
 sudo: false
 rvm:
   - 2.1.0
-  - 2.1.2
-  - 2.2.2
+  - 2.2.0
+  - 2.3.0
+  - 2.4.0
   - ruby-head

--- a/fandom-word.gemspec
+++ b/fandom-word.gemspec
@@ -15,4 +15,5 @@ Gem::Specification.new do |spec|
                      .reject { |file| file.match(/^(spec|word-lists|build)/) }
   spec.homepage    = 'http://github.com/RaviN/fandom-word'
   spec.license     = 'Unlicense'
+  spec.required_ruby_version = '>= 2.1.0'
 end


### PR DESCRIPTION
ruby 2.1.0 and greater is stable and passes in CI. When testing ruby 2.0.0 in travis, build failed due to rubocop. We could probably work around it, but at this point I see no need.